### PR TITLE
Create a homedir for the ansible user prior to copying keys

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -19,7 +19,7 @@
         groups: ansible
         append: yes
         state: present
-        createhome: no
+        createhome: yes
       become: true
 
     - name: Set up authorized keys for the ansible user


### PR DESCRIPTION
The homedir shall be created as the user is setup though the keys could actually be transferred into the .ssh folder of the user.